### PR TITLE
feat: return false explicitly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,8 @@ function hasGlobalInstallation(pm: PM): Promise<boolean> {
     .then((value) => {
       cache.set(key, value);
       return value;
-    });
+    })
+    .catch(() => false);
 }
 
 function getTypeofLockFile(cwd = "."): Promise<PM | null> {


### PR DESCRIPTION
Hi.
Now `await hasGlobalInstallation(...)` returns `true` or raise an error.
I think it's better to return `false`