### PR TITLE
Add types to exportMap in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "default": "./dist/index.mjs"
     }


### PR DESCRIPTION
This should allow typescript to find the types for the module when `"moduleResolution": "Bundler"`.

Here's the error I'm seeing:
```
Could not find a declaration file for module 'detect-package-manager'. '/Users/../storybook/code/node_modules/detect-package-manager/dist/index.mjs' implicitly has an 'any' type.
  There are types at '/Users/me/../storybook/code/node_modules/detect-package-manager/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'detect-package-manager' library may need to update its package.json or typings.ts(7016)
  ```